### PR TITLE
fixes rendering issue on server

### DIFF
--- a/src/server/middleware/render.js
+++ b/src/server/middleware/render.js
@@ -29,7 +29,7 @@ function render(config) {
       store.dispatch(setRuntimeVariable('cdnUrl', config.cdnUrl));
 
       await UniversalRouter.resolve(routes, {
-        path: req.path,
+        path: req.baseUrl, // this should really be `req.path`, but that is returning `/` for `/about` and `/champion/:key`
         query: req.query,
         context: {
           insertCss: (...styles) => {


### PR DESCRIPTION
`req.path` was set to `/` for paths like `/about` and `/champion/Lulu`
on the server. This caused the server to render the home page for those
routes.
